### PR TITLE
add gemm code

### DIFF
--- a/gemm/Makefile
+++ b/gemm/Makefile
@@ -1,0 +1,10 @@
+CC_FILES=$(shell find ./ -name "*.cu")
+EXE_FILES=$(CC_FILES:.cu=)
+
+all:$(EXE_FILES)
+
+%:%.cu
+	nvcc -o $@ $< -O2 -arch=sm_86 -std=c++17 -I../4th/cutlass/include --expt-relaxed-constexpr -cudart shared --cudadevrt none -lcublasLt -lcublas
+
+clean:
+	rm -rf $(EXE_FILES)

--- a/gemm/detail/cublaslt-gemm.h
+++ b/gemm/detail/cublaslt-gemm.h
@@ -1,0 +1,138 @@
+#include <cublasLt.h>
+#include <cuda_fp16.h>
+#include <stdio.h>
+
+#define check(call)                                        \
+  do {                                                     \
+    auto err = call;                                       \
+    if (err != CUBLAS_STATUS_SUCCESS) {                    \
+      printf("err = %d, str = %s, line = %d, %s\n", err,   \
+             cublasGetStatusString(err), __LINE__, #call); \
+      exit(0);                                             \
+    }                                                      \
+  } while (0)
+
+template <typename T>
+struct ComputeTypeTraits {
+  static constexpr cublasComputeType_t kComputeType = CUBLAS_COMPUTE_16F;
+  static constexpr cudaDataType_t kScaleType = CUDA_R_16F;
+};
+
+template <>
+struct ComputeTypeTraits<float> {
+  static constexpr cublasComputeType_t kComputeType = CUBLAS_COMPUTE_32F;
+  static constexpr cudaDataType_t kScaleType = CUDA_R_32F;
+};
+
+template <typename T, typename ComputeType = T>
+struct CublasLtGemm {
+  cublasLtHandle_t handle_;
+
+  cublasLtMatrixLayout_t a_desc_;
+  cublasLtMatrixLayout_t b_desc_;
+  cublasLtMatrixLayout_t c_desc_;
+
+  cublasLtMatmulDesc_t matmul_desc_;
+
+  cublasLtMatmulPreference_t preference_;
+
+  static constexpr int kAlgoMaxNum = 1024;
+  cublasLtMatmulHeuristicResult_t algos_[kAlgoMaxNum];
+  int ret_algo_num_;
+
+  ComputeType alpha_;
+  ComputeType beta_;
+  static constexpr cublasComputeType_t kComputeType =
+      ComputeTypeTraits<ComputeType>::kComputeType;
+  static constexpr cudaDataType_t kScaleType =
+      ComputeTypeTraits<ComputeType>::kScaleType;
+
+  void *workspace_;
+  int workspace_size_;
+
+  const void *a_;
+  const void *b_;
+  void *c_;
+
+  void init(T *c, const T *a, const T *b, int m, int n, int k);
+  bool run();
+};
+
+template <typename T, typename ComputeType>
+bool CublasLtGemm<T, ComputeType>::run() {
+  for (int i = 0; i < ret_algo_num_; ++i) {
+    auto algo = algos_[i];
+
+    /*
+    printf("algo-id = %d, workspace_size = %zu, waves = %f\n", i,
+    algo.workspaceSize, algo.wavesCount);
+    */
+
+    check(cublasLtMatmul(handle_, matmul_desc_, &alpha_, a_, a_desc_, b_,
+                         b_desc_, &beta_, c_, c_desc_, c_, c_desc_,
+                         &(algo.algo), workspace_, workspace_size_, 0));
+  }
+  return true;
+}
+
+template <typename T, typename ComputeType>
+void CublasLtGemm<T, ComputeType>::init(T *c, const T *a, const T *b, int m,
+                                        int n, int k) {
+  auto version = cublasLtGetVersion();
+  printf("cublasLt version: %zu\n", version);
+
+  check(cublasLtCreate(&handle_));
+
+  // cublasLtLoggerSetLevel(5);
+
+  int batch = 1;
+  int64_t a_stride = m * k;
+  int64_t b_stride = n * k;
+  int64_t c_stride = m * n;
+  cublasOperation_t transa = CUBLAS_OP_T;
+  cublasOperation_t transb = CUBLAS_OP_N;
+
+  check(cublasLtMatrixLayoutCreate(&a_desc_, CUDA_R_16F, k, m, k));
+  check(cublasLtMatrixLayoutCreate(&b_desc_, CUDA_R_16F, k, n, k));
+  check(cublasLtMatrixLayoutCreate(&c_desc_, CUDA_R_16F, m, n, m));
+
+  check(cublasLtMatrixLayoutSetAttribute(
+      a_desc_, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &batch, sizeof(batch)));
+  check(cublasLtMatrixLayoutSetAttribute(
+      b_desc_, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &batch, sizeof(batch)));
+  check(cublasLtMatrixLayoutSetAttribute(
+      c_desc_, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &batch, sizeof(batch)));
+
+  check(cublasLtMatrixLayoutSetAttribute(
+      a_desc_, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &a_stride,
+      sizeof(a_stride)));
+  check(cublasLtMatrixLayoutSetAttribute(
+      b_desc_, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &b_stride,
+      sizeof(b_stride)));
+  check(cublasLtMatrixLayoutSetAttribute(
+      c_desc_, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &c_stride,
+      sizeof(c_stride)));
+
+  check(cublasLtMatmulDescCreate(&matmul_desc_, kComputeType, kScaleType));
+  check(cublasLtMatmulDescSetAttribute(
+      matmul_desc_, CUBLASLT_MATMUL_DESC_TRANSA, &transa, sizeof(transa)));
+  check(cublasLtMatmulDescSetAttribute(
+      matmul_desc_, CUBLASLT_MATMUL_DESC_TRANSB, &transb, sizeof(transb)));
+
+  alpha_ = 1.f;
+  beta_ = 0.f;
+  workspace_ = nullptr;
+  workspace_size_ = 0;
+
+  cublasLtMatmulPreferenceCreate(&preference_);
+
+  cublasLtMatmulAlgoGetHeuristic(handle_, matmul_desc_, a_desc_, b_desc_,
+                                 c_desc_, c_desc_, preference_, kAlgoMaxNum,
+                                 algos_, &ret_algo_num_);
+
+  a_ = a;
+  b_ = b;
+  c_ = c;
+}
+
+#undef check

--- a/gemm/detail/data.h
+++ b/gemm/detail/data.h
@@ -1,0 +1,213 @@
+#include <cuda.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+template <typename T>
+void cpu_rand_data(T *c);
+
+template <typename T>
+void cpu_const_data(T *c, float k);
+
+template <typename T>
+void cpu_gemm(T *c, const T &a, const T &b);
+
+template <typename T>
+void cpu_compare(const T &x, const T &y, float threshold = 1.E-1);
+
+template <typename T>
+void gpu_compare(const T *x, const T *y, int n, float threshold = 1.E-1);
+
+void printf_fail(const char *fmt, ...) {
+  int red = 31;
+  int def = 39;
+
+  printf("\033[%dm", red);
+
+  va_list args;
+  va_start(args, fmt);
+  vprintf(fmt, args);
+  va_end(args);
+
+  printf("\033[%dm", def);
+}
+
+void printf_ok(const char *fmt, ...) {
+  int red = 32;
+  int def = 39;
+
+  printf("\033[%dm", red);
+
+  va_list args;
+  va_start(args, fmt);
+  vprintf(fmt, args);
+  va_end(args);
+
+  printf("\033[%dm", def);
+}
+
+template <typename T>
+void cpu_rand_data(T *c) {
+  auto t = *c;
+
+  using ValueType = typename T::value_type;
+
+  int n = size(t);
+  for (int i = 0; i < n; ++i) {
+    float v = ((rand() % 200) - 100.f) * 0.01f;
+    // printf("v = %f\n", v);
+    t(i) = ValueType(v);
+  }
+}
+
+template <typename T>
+void cpu_const_data(T *c, float k) {
+  auto t = *c;
+
+  int n = size(t);
+  for (int i = 0; i < n; ++i) {
+    t(i) = k;
+  }
+}
+
+template <typename T>
+void cpu_gemm(T *c, const T &a, const T &b) {
+  using namespace cute;
+
+  using ValueType = typename T::value_type;
+
+  int m = size<0>(a);
+  int n = size<0>(b);
+  int k = size<1>(a);
+
+  for (int i = 0; i < m; ++i) {
+    for (int j = 0; j < n; ++j) {
+      float s = 0.f;
+
+      for (int kk = 0; kk < k; ++kk) {
+        float v1 = a(i, kk);
+        float v2 = b(j, kk);
+        s += v1 * v2;
+      }
+
+      (*c)(i, j) = ValueType(s);
+    }
+  }
+}
+
+template <typename T>
+void cpu_compare(const T &x, const T &y, float threshold) {
+  using namespace cute;
+
+  if (size(x) != size(y)) {
+    fprintf(stderr, "lenght not equal x = %d, y = %d\n", size(x), size(y));
+    exit(9);
+  }
+
+  int n = size(x);
+  float diff_max = 0;
+  int diff_count = 0;
+  for (int i = 0; i < n; ++i) {
+    float v0 = x(i);
+    float v1 = y(i);
+
+    diff_max = max(diff_max, fabs(v0 - v1));
+
+    if (fabs(v0 - v1) > threshold) {
+      ++diff_count;
+    }
+  }
+  if (diff_count > 0) {
+    printf("check fail: max_diff = %f, diff_count = %d\n", diff_max,
+           diff_count);
+  } else {
+    printf("cpu check ok\n");
+  }
+}
+
+template <typename T>
+__global__ void gpu_compare_kernel(const T *x, const T *y, int n,
+                                   float threshold, int *count,
+                                   float *max_error) {
+  int idx = threadIdx.x + blockIdx.x * blockDim.x;
+
+  if (idx >= n) {
+    return;
+  }
+
+  float v0 = x[idx];
+  float v1 = y[idx];
+
+  float diff = fabs(v0 - v1);
+  if (diff > threshold) {
+    atomicAdd(count, 1);
+
+    // for positive floating point, there int representation is in the same
+    // order.
+    int int_diff = *((int *)(&diff));
+    atomicMax((int *)max_error, int_diff);
+  }
+}
+
+template <typename T>
+void gpu_compare(const T *x, const T *y, int n, float threshold) {
+  int *num_count;
+  float *max_error;
+  cudaMalloc(&num_count, sizeof(int));
+  cudaMalloc(&max_error, sizeof(float));
+  cudaMemset(num_count, 0, sizeof(int));
+  cudaMemset(max_error, 0, sizeof(float));
+
+  dim3 block(256);
+  dim3 grid((n + block.x - 1) / block.x);
+  gpu_compare_kernel<<<grid, block>>>(x, y, n, threshold, num_count, max_error);
+  int num = 0;
+  float error = 0;
+  cudaMemcpy(&num, num_count, sizeof(int), cudaMemcpyDeviceToHost);
+  cudaMemcpy(&error, max_error, sizeof(int), cudaMemcpyDeviceToHost);
+  cudaDeviceSynchronize();
+
+  if (num == 0) {
+    printf_ok("check ok, max_error = %f\n", error);
+  } else {
+    float p = (100.f * num) / n;
+    printf_fail("===============================\n");
+    printf_fail("check fail: diff %.1f%% = %d/%d max_error = %f\n", p, num, n,
+                error);
+    printf_fail("===============================\n");
+  }
+}
+
+static bool split_key_and_val(std::string *key, std::string *val,
+                              const std::string &kv_and_eq) {
+  auto it = kv_and_eq.find('=');
+  if (it == std::string::npos) {
+    return false;
+  }
+
+  *key = kv_and_eq.substr(0, it);
+  *val = kv_and_eq.substr(it + 1);
+  return true;
+}
+
+void Parse(int *val_out, const char *key_s, int argc, char *argv[]) {
+  const std::string target(key_s);
+  bool ok = false;
+  for (int i = 0; i < argc; ++i) {
+    std::string s(argv[i]);
+
+    std::string key, val;
+    if (!split_key_and_val(&key, &val, s)) {
+      continue;
+    }
+
+    if (key == target) {
+      *val_out = std::stoi(val);
+      ok = true;
+    }
+  }
+
+  if (!ok) {
+    printf("%s not found in program argv, set it to default %d\n",
+           target.c_str(), *val_out);
+  }
+}

--- a/gemm/gemm-multi-stage.cu
+++ b/gemm/gemm-multi-stage.cu
@@ -1,0 +1,478 @@
+#include <cublas_v2.h>
+#include <cuda.h>
+#include <stdarg.h>
+#include <stdio.h>
+
+#include <cute/tensor.hpp>
+
+#include "detail/cublaslt-gemm.h"
+#include "detail/data.h"
+
+template <typename Config>
+__global__ void /* __launch_bounds__(128, 1) */
+gemm_multi_stage(void *Dptr, const void *Aptr, const void *Bptr, int m, int n,
+                 int k) {
+  using namespace cute;
+  using X = Underscore;
+
+  using T = typename Config::T;
+  using SmemLayoutA = typename Config::SmemLayoutA;
+  using SmemLayoutB = typename Config::SmemLayoutB;
+  using SmemLayoutC = typename Config::SmemLayoutC;
+  using TiledMMA = typename Config::MMA;
+
+  using S2RCopyAtomA = typename Config::S2RCopyAtomA;
+  using S2RCopyAtomB = typename Config::S2RCopyAtomB;
+  using G2SCopyA = typename Config::G2SCopyA;
+  using G2SCopyB = typename Config::G2SCopyB;
+  using R2SCopyAtomC = typename Config::R2SCopyAtomC;
+  using S2GCopyAtomC = typename Config::S2GCopyAtomC;
+  using S2GCopyC = typename Config::S2GCopyC;
+
+  constexpr int kTileM = Config::kTileM;
+  constexpr int kTileN = Config::kTileN;
+  constexpr int kTileK = Config::kTileK;
+  constexpr int kStage = Config::kStage;
+
+  extern __shared__ T shm_data[];
+
+  T *Ashm = shm_data;
+  T *Bshm = shm_data + cute::cosize(SmemLayoutA{});
+
+  int idx = threadIdx.x;
+  int ix = blockIdx.x;
+  int iy = blockIdx.y;
+
+  // use Tensor notation to represent device pointer + dimension
+  Tensor A = make_tensor(make_gmem_ptr((T *)Aptr), make_shape(m, k),
+                         make_stride(k, Int<1>{}));  // (M, K)
+  Tensor B = make_tensor(make_gmem_ptr((T *)Bptr), make_shape(n, k),
+                         make_stride(k, Int<1>{}));  // (N, K)
+  Tensor D = make_tensor(make_gmem_ptr((T *)Dptr), make_shape(m, n),
+                         make_stride(n, Int<1>{}));  // (M, N)
+
+  // slice the tensor to small one which is used for current thread block.
+  Tensor gA = local_tile(A, make_tile(Int<kTileM>{}, Int<kTileK>{}),
+                         make_coord(iy, _));  // (kTileM, kTileK, k)
+  Tensor gB = local_tile(B, make_tile(Int<kTileN>{}, Int<kTileK>{}),
+                         make_coord(ix, _));  // (kTileN, kTileK, k)
+  Tensor gD = local_tile(D, make_tile(Int<kTileM>{}, Int<kTileN>{}),
+                         make_coord(iy, ix));  // (kTileM, kTileN)
+
+  // shared memory
+  auto sA = make_tensor(make_smem_ptr(Ashm),
+                        SmemLayoutA{});  // (kTileM, kTileK, kStage)
+  auto sB = make_tensor(make_smem_ptr(Bshm),
+                        SmemLayoutB{});  // (kTileN, kTileK, kStage)
+
+  // dispatch TileA/TileB/TileC mma tensor into thread fragment via partition
+  // method
+  TiledMMA tiled_mma;
+  auto thr_mma = tiled_mma.get_slice(idx);
+  auto tCrA = thr_mma.partition_fragment_A(gA(_, _, 0));  // (MMA, MMA_M, MMA_K)
+  auto tCrB = thr_mma.partition_fragment_B(gB(_, _, 0));  // (MMA, MMA_N, MMA_K)
+  auto tCrD = thr_mma.partition_fragment_C(gD);           // (MMA, MMA_M, MMA_N)
+
+  // fill zero for accumulator
+  clear(tCrD);
+
+  // gmem -cp.async-> shm -ldmatrix-> reg
+  auto s2r_tiled_copy_a = make_tiled_copy_A(S2RCopyAtomA{}, tiled_mma);
+  auto s2r_thr_copy_a = s2r_tiled_copy_a.get_slice(idx);
+  auto tAsA = s2r_thr_copy_a.partition_S(sA);  // ? (CPY, CPY_M, CPY_K, kStage)
+  auto tCrA_view = s2r_thr_copy_a.retile_D(tCrA);  // ? (CPY, CPY_M, CPY_K)
+
+  auto s2r_tiled_copy_b = make_tiled_copy_B(S2RCopyAtomB{}, tiled_mma);
+  auto s2r_thr_copy_b = s2r_tiled_copy_b.get_slice(idx);
+  auto tBsB = s2r_thr_copy_b.partition_S(sB);  // ? (CPY, CPY_M, CPY_K, kStage)
+  auto tCrB_view = s2r_thr_copy_b.retile_D(tCrB);  // ? (CPY, CPY_M, CPY_K)
+
+  G2SCopyA g2s_tiled_copy_a;
+  auto g2s_thr_copy_a = g2s_tiled_copy_a.get_slice(idx);
+  auto tAgA_copy = g2s_thr_copy_a.partition_S(gA);  // (CPY, CPY_M, CPY_K, k)
+  auto tAsA_copy =
+      g2s_thr_copy_a.partition_D(sA);  // (CPY, CPY_M, CPY_K, kStage)
+
+  G2SCopyB g2s_tiled_copy_b;
+  auto g2s_thr_copy_b = g2s_tiled_copy_b.get_slice(idx);
+  auto tBgB_copy = g2s_thr_copy_b.partition_S(gB);  // (CPY, CPY_N, CPY_K, k)
+  auto tBsB_copy =
+      g2s_thr_copy_b.partition_D(sB);  // (CPY, CPY_N, CPY_K, kStage)
+
+  int itile_to_read = 0;
+  int ismem_read = 0;
+  int ismem_write = 0;
+
+  // submit kStage - 1 tile
+  // gmem -> shm
+#pragma unroll
+  for (int istage = 0; istage < kStage - 1; ++istage) {
+    cute::copy(g2s_tiled_copy_a, tAgA_copy(_, _, _, istage),
+               tAsA_copy(_, _, _, istage));
+    cute::copy(g2s_tiled_copy_b, tBgB_copy(_, _, _, istage),
+               tBsB_copy(_, _, _, istage));
+    cp_async_fence();
+
+    ++itile_to_read;
+    ++ismem_write;
+  }
+
+  // wait one submitted gmem->smem done
+  cp_async_wait<kStage - 2>();
+  __syncthreads();
+
+  int ik = 0;
+  // smem -> reg
+  cute::copy(s2r_tiled_copy_a, tAsA(_, _, ik, ismem_read), tCrA_view(_, _, ik));
+  cute::copy(s2r_tiled_copy_b, tBsB(_, _, ik, ismem_read), tCrB_view(_, _, ik));
+
+  // loop over k: i. load tile, ii. mma
+  int ntile = k / kTileK;
+#pragma unroll 1
+  for (int itile = 0; itile < ntile; ++itile) {
+    int nk = size<2>(tCrA);
+
+#pragma unroll
+    for (int ik = 0; ik < nk; ++ik) {
+      int ik_next = (ik + 1) % nk;
+
+      if (ik == nk - 1) {
+        cp_async_wait<kStage - 2>();
+        __syncthreads();
+
+        ismem_read = (ismem_read + 1) % kStage;
+      }
+
+      // shm -> reg s[itile][ik + 1] -> r[ik + 1]
+      cute::copy(s2r_tiled_copy_a, tAsA(_, _, ik_next, ismem_read),
+                 tCrA_view(_, _, ik_next));
+      cute::copy(s2r_tiled_copy_b, tBsB(_, _, ik_next, ismem_read),
+                 tCrB_view(_, _, ik_next));
+
+      if (ik == 0) {
+        if (itile_to_read < ntile) {
+          cute::copy(g2s_tiled_copy_a, tAgA_copy(_, _, _, itile_to_read),
+                     tAsA_copy(_, _, _, ismem_write));
+          cute::copy(g2s_tiled_copy_b, tBgB_copy(_, _, _, itile_to_read),
+                     tBsB_copy(_, _, _, ismem_write));
+
+          ++itile_to_read;
+          ismem_write = (ismem_write + 1) % kStage;
+        }
+
+        cp_async_fence();
+      }
+
+      cute::gemm(tiled_mma, tCrD, tCrA(_, _, ik), tCrB(_, _, ik), tCrD);
+    }  // for ik
+  }    // itile
+
+  // use less shared memory as a scratchpad tile to use large wide instuction
+  // Dreg -> shm -> reg -> global
+  auto sC = make_tensor(sA(_, _, ismem_read).data(), SmemLayoutC{});
+
+  auto r2s_tiled_copy_c = make_tiled_copy_C(R2SCopyAtomC{}, tiled_mma);
+  auto r2s_thr_copy_c = r2s_tiled_copy_c.get_slice(idx);
+  auto tCrC_r2s = r2s_thr_copy_c.retile_S(tCrD);   // (CPY, CPY_M, CPY_N)
+  auto tCsC_r2s = r2s_thr_copy_c.partition_D(sC);  // (CPY, _1, _1, pipe)
+
+  S2GCopyC s2g_tiled_copy_c;
+  auto s2g_thr_copy_c = s2g_tiled_copy_c.get_thread_slice(idx);
+  auto tCsC_s2g = s2g_thr_copy_c.partition_S(sC);  // (CPY, _1, _1, pipe)
+  auto tCgC_s2g = s2g_thr_copy_c.partition_D(gD);  // (CPY, CPY_M, CPY_N)
+
+  auto tCgC_s2gx = group_modes<1, 3>(tCgC_s2g);  // (CPY_, CPY_MN)
+  auto tCrC_r2sx = group_modes<1, 3>(tCrC_r2s);  // (CPY_, CPY_MN)
+
+  int step = size<3>(tCsC_r2s);  // pipe
+#pragma unroll
+  for (int i = 0; i < size<1>(tCrC_r2sx); i += step) {
+    // reg -> shm
+#pragma unroll
+    for (int j = 0; j < step; ++j) {
+      // we add a temp tensor to cope with accumulator and output data type
+      // difference
+      auto t = make_tensor_like<T>(tCrC_r2sx(_, i + j));
+      cute::copy(tCrC_r2sx(_, i + j), t);
+
+      cute::copy(r2s_tiled_copy_c, t, tCsC_r2s(_, 0, 0, j));
+    }
+    __syncthreads();
+
+#pragma unroll
+    // shm -> global
+    for (int j = 0; j < step; ++j) {
+      cute::copy(s2g_tiled_copy_c, tCsC_s2g(_, 0, 0, j), tCgC_s2gx(_, i + j));
+    }
+
+    __syncthreads();
+  }
+}
+
+namespace config {
+
+using namespace cute;
+
+template <typename T_, int kTileM_ = 128, int kTileN_ = 128, int kTileK_ = 32,
+          int kStage_ = 5, int kSmemLayoutCBatch_ = 2,
+          typename ComputeType = T_>
+struct GemmConfig {
+  using T = T_;
+
+  // tile configuration
+  static constexpr int kTileM = kTileM_;
+  static constexpr int kTileN = kTileN_;
+  static constexpr int kTileK = kTileK_;
+  static constexpr int kStage = kStage_;
+  static constexpr int kSmemLayoutCBatch = kSmemLayoutCBatch_;
+
+  static constexpr int kShmLoadSwizzleM = 3;
+  static constexpr int kShmLoadSwizzleS = 3;
+  static constexpr int kShmLoadSwizzleB = 3;
+
+  using SmemLayoutAtom = decltype(composition(
+      Swizzle<kShmLoadSwizzleB, kShmLoadSwizzleM, kShmLoadSwizzleS>{},
+      make_layout(make_shape(Int<8>{}, Int<kTileK>{}),
+                  make_stride(Int<kTileK>{}, Int<1>{}))));
+  using SmemLayoutA = decltype(
+      tile_to_shape(SmemLayoutAtom{},
+                    make_shape(Int<kTileM>{}, Int<kTileK>{}, Int<kStage>{})));
+  using SmemLayoutB = decltype(
+      tile_to_shape(SmemLayoutAtom{},
+                    make_shape(Int<kTileN>{}, Int<kTileK>{}, Int<kStage>{})));
+
+  using mma_op = SM80_16x8x16_F16F16F16F16_TN;
+
+  using mma_traits = MMA_Traits<mma_op>;
+  using mma_atom = MMA_Atom<mma_traits>;
+
+  static constexpr int kMmaEURepeatM = 2;
+  static constexpr int kMmaEURepeatN = 2;
+  static constexpr int kMmaEURepeatK = 1;
+
+  using mma_atom_shape = mma_traits::Shape_MNK;
+  static constexpr int kMmaPM = 1 * kMmaEURepeatM * get<0>(mma_atom_shape{});
+  static constexpr int kMmaPN = 2 * kMmaEURepeatN * get<1>(mma_atom_shape{});
+  static constexpr int kMmaPK = 1 * kMmaEURepeatK * get<2>(mma_atom_shape{});
+
+  using MMA_EU_RepeatT = decltype(make_layout(make_shape(
+      Int<kMmaEURepeatM>{}, Int<kMmaEURepeatN>{}, Int<kMmaEURepeatK>{})));
+  using MMA_P_T = Tile<Int<kMmaPM>, Int<kMmaPN>, Int<kMmaPK>>;
+
+  using MMA = decltype(make_tiled_mma(mma_atom{}, MMA_EU_RepeatT{}, MMA_P_T{}));
+
+  using g2s_copy_op = SM80_CP_ASYNC_CACHEGLOBAL<cute::uint128_t>;
+  using g2s_copy_traits = Copy_Traits<g2s_copy_op>;
+  using g2s_copy_atom = Copy_Atom<g2s_copy_traits, T>;
+
+  using G2SCopyA =
+      decltype(make_tiled_copy(g2s_copy_atom{},
+                               make_layout(make_shape(Int<32>{}, Int<4>{}),
+                                           make_stride(Int<4>{}, Int<1>{})),
+                               make_layout(make_shape(Int<1>{}, Int<8>{}))));
+  using G2SCopyB = G2SCopyA;
+
+  // shared memory to register copy
+  using s2r_copy_op = SM75_U32x4_LDSM_N;
+  using s2r_copy_traits = Copy_Traits<s2r_copy_op>;
+  using s2r_copy_atom = Copy_Atom<s2r_copy_traits, T>;
+
+  using S2RCopyAtomA = s2r_copy_atom;
+  using S2RCopyAtomB = s2r_copy_atom;
+
+  // epilogue: register to global via shared memory
+  using SmemLayoutAtomC = decltype(composition(
+      Swizzle<2, 3, 3>{}, make_layout(make_shape(Int<kMmaPM>{}, Int<kMmaPN>{}),
+                                      make_stride(Int<kMmaPN>{}, Int<1>{}))));
+  using SmemLayoutC = decltype(tile_to_shape(
+      SmemLayoutAtomC{},
+      make_shape(Int<kMmaPM>{}, Int<kMmaPN>{}, Int<kSmemLayoutCBatch>{})));
+
+  static_assert(size<0>(SmemLayoutA{}) * size<1>(SmemLayoutA{}) >=
+                    size(SmemLayoutC{}),
+                "C shared memory request is large than A's one pipe");
+
+  using R2SCopyAtomC = Copy_Atom<UniversalCopy<int>, T>;
+
+  using S2GCopyAtomC = Copy_Atom<UniversalCopy<cute::uint128_t>, T>;
+  using S2GCopyC =
+      decltype(make_tiled_copy(S2GCopyAtomC{},
+                               make_layout(make_shape(Int<32>{}, Int<4>{}),
+                                           make_stride(Int<4>{}, Int<1>{})),
+                               make_layout(make_shape(Int<1>{}, Int<8>{}))));
+
+  static constexpr int kThreadNum = size(MMA{});
+  static constexpr int shm_size_AB =
+      cute::cosize(SmemLayoutA{}) + cute::cosize(SmemLayoutB{});
+  static constexpr int shm_size_C = cute::cosize(SmemLayoutC{});
+
+  static constexpr int kShmSize =
+      cute::max(shm_size_AB, shm_size_C) * sizeof(T);
+};
+
+}  // namespace config
+
+int main(int argc, char *argv[]) {
+  using T = cute::half_t;
+  using namespace cute;
+  using X = Underscore;
+
+  srand(10086);
+
+  cublasHandle_t handle;
+  cublasCreate(&handle);
+  int cublas_version;
+  cublasGetVersion_v2(handle, &cublas_version);
+  printf("cuBLAS version: %d\n", cublas_version);
+
+  // default;
+  int M = 81920;
+  int N = 256;
+  int K = 256;
+
+  int enable_cpu = 0;
+  int enable_cublaslt = 1;
+  int nt = 11;
+
+  using ComputeType = T;
+
+  T *Aptr;
+  T *Bptr;
+  T *Dptr;
+  T *Dptr_cublas;
+  T *Dptr_cublaslt;
+
+  T *Aptr_host;
+  T *Bptr_host;
+  T *Dptr_host;
+  T *Dptr_host_cpu;
+  T *Dptr_host_blas;
+  T *Dptr_host_cublaslt;
+
+  Aptr_host = (T *)malloc(sizeof(T) * M * K);
+  Bptr_host = (T *)malloc(sizeof(T) * N * K);
+  Dptr_host = (T *)malloc(sizeof(T) * M * N);
+
+  Dptr_host_cpu = (T *)malloc(sizeof(T) * M * N);
+  Dptr_host_blas = (T *)malloc(sizeof(T) * M * N);
+  Dptr_host_cublaslt = (T *)malloc(sizeof(T) * M * N);
+
+  cudaMalloc(&Aptr, sizeof(T) * M * K);
+  cudaMalloc(&Bptr, sizeof(T) * N * K);
+  cudaMalloc(&Dptr, sizeof(T) * M * N);
+  cudaMalloc(&Dptr_cublas, sizeof(T) * M * N);
+  cudaMalloc(&Dptr_cublaslt, sizeof(T) * M * N);
+
+  auto tA = make_tensor(Aptr_host, make_shape(M, K), make_stride(K, 1));
+  auto tB = make_tensor(Bptr_host, make_shape(N, K), make_stride(K, 1));
+  auto tD = make_tensor(Dptr_host, make_shape(M, N), make_stride(N, 1));
+
+  cpu_rand_data(&tA);
+  cpu_rand_data(&tB);
+
+  clear(tD);
+
+  cudaMemcpy(Aptr, Aptr_host, sizeof(T) * M * K, cudaMemcpyHostToDevice);
+  cudaMemcpy(Bptr, Bptr_host, sizeof(T) * N * K, cudaMemcpyHostToDevice);
+  cudaMemcpy(Dptr, Dptr_host, sizeof(T) * M * N, cudaMemcpyHostToDevice);
+  cudaMemset(Dptr_cublas, 0, sizeof(T) * M * N);
+  cudaMemset(Dptr_cublaslt, 0, sizeof(T) * M * N);
+
+  CublasLtGemm<T, ComputeType> cublaslt_gemm;
+  if (enable_cublaslt) {
+    cublaslt_gemm.init(Dptr_cublaslt, Bptr, Aptr, N, M, K);
+  }
+
+  config::GemmConfig<T, 128, 128, 32, 3> gemm_config;
+
+  print(typename decltype(gemm_config)::MMA{});
+
+  dim3 block = gemm_config.kThreadNum;
+  dim3 grid((N + gemm_config.kTileN - 1) / gemm_config.kTileN,
+            (M + gemm_config.kTileM - 1) / gemm_config.kTileM);
+  int shm_size = gemm_config.kShmSize;
+
+  half alpha = 1.f;
+  half beta = 0.f;
+
+  for (int it = 0; it < nt; ++it) {
+    // blas
+    cudaMemset(Dptr_cublas, 0, sizeof(T) * M * N);
+    cublasStatus_t ret = cublasHgemm(handle, CUBLAS_OP_T, CUBLAS_OP_N, N, M, K,
+                                     &alpha, (half *)Bptr, K, (half *)Aptr, K,
+                                     &beta, (half *)Dptr_cublas, N);
+    if (ret != CUBLAS_STATUS_SUCCESS) {
+      printf("cublas err = %d, str = %s\n", ret, cublasGetStatusString(ret));
+    }
+
+    if (enable_cublaslt) {
+      cudaMemset(Dptr_cublaslt, 0, sizeof(T) * M * N);
+      cublaslt_gemm.run();
+    }
+
+    // multi-stage
+    cudaMemset(Dptr, 0, sizeof(T) * M * N);
+    cudaFuncSetAttribute(gemm_multi_stage<decltype(gemm_config)>,
+                         cudaFuncAttributeMaxDynamicSharedMemorySize, shm_size);
+    gemm_multi_stage<decltype(gemm_config)>
+        <<<grid, block, shm_size>>>(Dptr, Aptr, Bptr, M, N, K);
+  }
+
+  cudaMemcpy(Dptr_host, Dptr, sizeof(T) * M * N, cudaMemcpyDeviceToHost);
+  cudaMemcpy(Dptr_host_blas, Dptr_cublas, sizeof(T) * M * N,
+             cudaMemcpyDeviceToHost);
+  cudaMemcpy(Dptr_host_cublaslt, Dptr_cublaslt, sizeof(T) * M * N,
+             cudaMemcpyDeviceToHost);
+
+  cudaDeviceSynchronize();
+  auto err = cudaGetLastError();
+  printf("block = (%d, %d), gird = (%d, %d), shm = %d\n", block.x, block.y,
+         grid.x, grid.y, shm_size);
+
+  if (err == cudaSuccess) {
+    printf("err = %d, str = %s\n", err, cudaGetErrorString(err));
+  } else {
+    printf_fail("err = %d, str = %s\n", err, cudaGetErrorString(err));
+  }
+
+  gpu_compare(Dptr, Dptr_cublas, M * N);
+
+  if (enable_cublaslt) {
+    gpu_compare(Dptr, Dptr_cublaslt, M * N);
+  }
+
+  auto tD_host = make_tensor(Dptr_host, make_shape(M, N), make_stride(N, 1));
+  auto tD_host_cpu =
+      make_tensor(Dptr_host_cpu, make_shape(M, N), make_stride(N, 1));
+  auto tD_host_blas =
+      make_tensor(Dptr_host_blas, make_shape(M, N), make_stride(N, 1));
+  auto tD_host_cublaslt =
+      make_tensor(Dptr_host_cublaslt, make_shape(M, N), make_stride(N, 1));
+
+  if (enable_cpu) {
+    cpu_gemm(&tD_host_cpu, tA, tB);
+    cpu_compare(tD_host_cpu, tD_host, 0.1f);
+  }
+
+  auto tile = make_tile(min(8, M), min(8, N));
+  auto t32x32 = local_tile(tD_host, tile, make_coord(0, 0));
+  auto t32x32_cpu = local_tile(tD_host_cpu, tile, make_coord(0, 0));
+  auto t32x32_blas = local_tile(tD_host_blas, tile, make_coord(0, 0));
+  auto t32x32_cublaslt = local_tile(tD_host_cublaslt, tile, make_coord(0, 0));
+
+  printf("M = %d, N = %d, K = %d\n", M, N, K);
+
+  printf("our-impl:\n");
+  print_tensor(t32x32);
+  if (enable_cpu) {
+    printf("cpu:\n");
+    print_tensor(t32x32_cpu);
+  }
+  printf("cublas:\n");
+  print_tensor(t32x32_blas);
+
+  if (enable_cublaslt) {
+    printf("cublaslt:\n");
+    print_tensor(t32x32_cublaslt);
+  }
+}

--- a/gemm/gemm-simple.cu
+++ b/gemm/gemm-simple.cu
@@ -1,0 +1,164 @@
+#include <cuda.h>
+#include <cublas_v2.h>
+#include <stdlib.h>
+#include <cute/tensor.hpp>
+
+template <typename T>
+void gen_rand_data(T *data, int n);
+
+template <typename T, int kTileM, int kTileN, int kTileK, typename TiledMMA>
+__global__ void gemm_simple(T *Cptr, const T *Aptr, const T *Bptr, int m, int n, int k) {
+
+  using namespace cute;
+
+  Tensor A = make_tensor(make_gmem_ptr(Aptr), make_shape(m, k), make_stride(k, Int<1>{}));
+  Tensor B = make_tensor(make_gmem_ptr(Bptr), make_shape(n, k), make_stride(k, Int<1>{}));
+  Tensor C = make_tensor(make_gmem_ptr(Cptr), make_shape(m, n), make_stride(n, Int<1>{}));
+
+  int ix = blockIdx.x;
+  int iy = blockIdx.y;
+
+  Tensor gA = local_tile(A, make_tile(Int<kTileM>{}, Int<kTileK>{}), make_coord(iy, _));
+  Tensor gB = local_tile(B, make_tile(Int<kTileN>{}, Int<kTileK>{}), make_coord(ix, _));
+  Tensor gC = local_tile(C, make_tile(Int<kTileM>{}, Int<kTileN>{}), make_coord(iy, ix));
+  //  gA(kTileM, kTileK, num_tile_k)
+  //  gB(kTileN, kTileK, num_tile_k)
+  //  gC(kTileM, kTileN) 
+
+  TiledMMA tiled_mma;
+  auto thr_mma = tiled_mma.get_slice(threadIdx.x);
+  auto tAgA = thr_mma.partition_A(gA);  // (MMA, MMA_M, MMA_K, num_tile_k)
+  auto tBgB = thr_mma.partition_B(gB);  // (MMA, MMA_N, MMA_K, num_tile_k)
+  auto tCgC = thr_mma.partition_C(gC);  // (MMA, MMA_M, MMA_N)
+
+  auto tArA = thr_mma.partition_fragment_A(gA(_, _, 0));  // (MMA, MMA_M, MMA_K)
+  auto tBrB = thr_mma.partition_fragment_B(gB(_, _, 0));  // (MMA, MMA_N, MMA_K)
+  auto tCrC = thr_mma.partition_fragment_C(gC(_, _));     // (MMA, MMA_M, MMA_N)
+ 
+  clear(tCrC);
+  
+  int num_tile_k = size<2>(gA);
+#pragma unroll 1
+  for(int itile = 0; itile < num_tile_k; ++itile) {
+    cute::copy(tAgA(_, _, _, itile), tArA);
+    cute::copy(tBgB(_, _, _, itile), tBrB);
+
+    cute::gemm(tiled_mma, tCrC, tArA, tBrB, tCrC);
+  }
+
+  cute::copy(tCrC, tCgC); 
+}
+
+int main() {
+  srand(10086);
+
+  using T = cute::half_t;
+  using namespace cute;
+
+  T *Cptr;
+  T *Aptr;
+  T *Bptr;
+
+  int m = 81920;
+  int n = 256;
+  int k = 256;
+
+  cudaMalloc(&Cptr, sizeof(T) * m * n);
+  cudaMalloc(&Aptr, sizeof(T) * m * k);
+  cudaMalloc(&Bptr, sizeof(T) * k * n);
+
+  T *Aptr_host;
+  T *Bptr_host;
+  Aptr_host = (T*)malloc(sizeof(T) * m * k);
+  Bptr_host = (T*)malloc(sizeof(T) * n * k);
+  gen_rand_data(Aptr_host, m * k);
+  gen_rand_data(Bptr_host, n * k);
+
+  cudaMemcpy(Aptr, Aptr_host, sizeof(T) * m * k, cudaMemcpyHostToDevice);
+  cudaMemcpy(Bptr, Bptr_host, sizeof(T) * n * k, cudaMemcpyHostToDevice);
+
+  using mma_op = SM80_16x8x16_F16F16F16F16_TN;
+  using mma_traits = MMA_Traits<mma_op>;
+  using mma_atom = MMA_Atom<mma_traits>;
+
+  using MMA = decltype(make_tiled_mma(mma_atom{}, 
+                      make_layout(Shape<_2, _2, _1>{}), 
+                      make_layout(Shape<_1, _2, _1>{})));
+  constexpr int kTileM = 128; 
+  constexpr int kTileN = 128; 
+  constexpr int kTileK = 32; 
+
+  dim3 block(size(MMA{}));
+  dim3 grid(n / kTileN, m / kTileM);
+  for (int i = 0; i < 100; ++i) {
+    gemm_simple<T, kTileM, kTileN, kTileK, MMA><<<grid, block>>>(Cptr, Aptr, Bptr, m, n, k);
+  }
+  cudaDeviceSynchronize();
+  auto err = cudaGetLastError();
+  printf("err = %d, str = %s\n", err, cudaGetErrorString(err));
+
+  // cublas
+  T *Cptr_cublas;
+
+  cudaMalloc(&Cptr_cublas, sizeof(T) * m * n);
+
+  cublasHandle_t handle;
+  cublasCreate(&handle);
+
+  half alpha = half(1.f);
+  half beta = half(0.f);
+  for (int i = 0; i < 100; ++i) {
+    cublasStatus_t ret = cublasHgemm(handle, CUBLAS_OP_T, CUBLAS_OP_N,
+          	  n, m, k,
+          	  &alpha,
+          	  (half *)Bptr, k,
+          	  (half *)Aptr, k,
+          	  &beta,
+          	  (half *)Cptr_cublas, n);
+    if (ret != CUBLAS_STATUS_SUCCESS) {
+      printf("blas err = %d, str = %s\n", ret, cublasGetStatusString(ret));
+    }
+  }
+
+  cudaDeviceSynchronize();
+  err = cudaGetLastError();
+  printf("err = %d, str = %s\n", err, cudaGetErrorString(err));
+
+  T *Cptr_host;
+  T *Cptr_cublas_host;
+
+  Cptr_host = (T*)malloc(sizeof(T) * m * n);
+  Cptr_cublas_host = (T*)malloc(sizeof(T) * m * n);
+
+  // compare
+  cudaMemcpy(Cptr_host, Cptr, sizeof(T) * m * n, cudaMemcpyDeviceToHost);
+  cudaMemcpy(Cptr_cublas_host, Cptr_cublas, sizeof(T) * m * n, cudaMemcpyDeviceToHost);
+
+  float threshold = 0.1;
+  for (int i = 0; i < m * n; ++i) {
+    float v1 = Cptr_host[i];
+    float v2 = Cptr_cublas_host[i];
+    if (fabs(v2 - v1) > threshold) {
+      printf("v1 = %f, v2 = %f\n", v1, v2);
+    }
+  }
+
+  Tensor tensor_C = make_tensor(Cptr_host, make_shape(m, n), make_stride(n, 1));
+  Tensor tensor_C_cublas = make_tensor(Cptr_cublas_host, make_shape(m, n), make_stride(n, 1));
+
+  auto tile = make_tile(8, 8);
+  auto coor = make_coord(0, 0);
+  Tensor tc1 = local_tile(tensor_C, tile, coor);
+  Tensor tc1_cublas = local_tile(tensor_C_cublas, tile, coor);
+
+  print_tensor(tc1);
+  print_tensor(tc1_cublas);
+}
+
+template <typename T>
+void gen_rand_data(T *data, int n) {
+  for (int i = 0; i < n; ++i) {
+    float v = (rand() % 200 - 100) * 0.01;
+    data[i] = v;
+  }
+}


### PR DESCRIPTION
This pull request introduces core infrastructure for GEMM (General Matrix Multiply) operations using CUDA, CUBLAS, and CUTLASS, including a simple GEMM kernel, utility functions for data generation and comparison, and a Makefile for streamlined building. The changes establish a foundation for benchmarking and validating custom GEMM implementations against CUBLAS.

**Build system:**
- Added a `Makefile` to automatically find and compile all `.cu` files in the `gemm` directory using `nvcc` with appropriate CUDA and CUTLASS flags.

**GEMM implementation and benchmarking:**
- Added `gemm-simple.cu`, which implements a tiled GEMM kernel using CUTLASS abstractions and benchmarks it against CUBLAS, including result comparison and tile-level output for debugging.

**Utility and helper functions:**
- Added `data.h` containing host and device utilities for random/constant data generation, CPU-side GEMM and result comparison, GPU-side result comparison kernels, and command-line parsing helpers.

**CUBLASLt integration:**
- Added `cublaslt-gemm.h`, providing a templated wrapper for configuring and running GEMM operations with CUBLASLt, including heuristic algorithm selection and error checking macros.